### PR TITLE
Add LLM configuration support and environment template

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+# Environment configuration for the multi-agent investment project.
+# Replace placeholder values with your actual credentials before enabling LLM-powered agents.
+LLM_PROVIDER=openrouter
+LLM_API_KEY=your_api_key_here
+LLM_BASE_URL=https://openrouter.ai/api/v1
+LLM_MODEL=gpt-4.1-mini
+LLM_TEMPERATURE=0.2
+LLM_MAX_TOKENS=1024

--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ pip install -r requirements.txt
 - pandas
 - numpy
 - yfinance
+- python-dotenv（選用，便於載入 `.env`）
+
+### 環境變數設定
+
+專案在根目錄提供了預設的 `.env` 檔案，可作為設定 LLM 供應商、API key 與模型等參數的範本：
+
+```env
+LLM_PROVIDER=openrouter
+LLM_API_KEY=your_api_key_here
+LLM_BASE_URL=https://openrouter.ai/api/v1
+LLM_MODEL=gpt-4.1-mini
+LLM_TEMPERATURE=0.2
+LLM_MAX_TOKENS=1024
+```
+
+若需啟用真實的 LLM 代理人，請將 `LLM_API_KEY` 改為有效的金鑰，並依需求調整模型與其他參數。程式會自動讀取 `.env`（若安裝 `python-dotenv`）或直接從系統環境變數載入設定。
 
 ## 使用方式
 

--- a/investment_company/__init__.py
+++ b/investment_company/__init__.py
@@ -1,4 +1,5 @@
 """Multi-agent investment research laboratory."""
+from .config import LLMConfig, load_llm_config
 from .orchestrator import InvestmentMeeting
 
-__all__ = ["InvestmentMeeting"]
+__all__ = ["InvestmentMeeting", "LLMConfig", "load_llm_config"]

--- a/investment_company/config.py
+++ b/investment_company/config.py
@@ -1,0 +1,113 @@
+"""Configuration helpers for environment and LLM settings."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_ENV_FILE = PROJECT_ROOT / ".env"
+
+
+def _load_dotenv(env_file: Path | None) -> None:
+    """Load variables from a ``.env`` file when ``python-dotenv`` is available."""
+
+    if env_file is None or not env_file.exists():
+        return
+
+    try:
+        from dotenv import load_dotenv
+    except ImportError:  # pragma: no cover - optional dependency
+        return
+
+    load_dotenv(dotenv_path=env_file, override=False)
+
+
+@dataclass
+class LLMConfig:
+    """Container for Large Language Model connection settings."""
+
+    provider: str
+    api_key: Optional[str]
+    base_url: Optional[str]
+    model: str
+    temperature: float
+    max_tokens: int
+
+    def headers(self) -> Dict[str, str]:
+        """Return default HTTP headers for REST-based providers."""
+
+        headers: Dict[str, str] = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        if self.provider.lower() == "openrouter":
+            headers.setdefault("HTTP-Referer", "https://github.com/")
+        return headers
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialize the configuration for debugging or logging purposes."""
+
+        return {
+            "provider": self.provider,
+            "base_url": self.base_url,
+            "model": self.model,
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+            "has_api_key": bool(self.api_key),
+        }
+
+
+def load_llm_config(
+    env_file: Path | None = None,
+    *,
+    require_api_key: bool = False,
+) -> LLMConfig:
+    """Load :class:`LLMConfig` from environment variables.
+
+    Parameters
+    ----------
+    env_file:
+        Optional explicit path to a ``.env`` file. Defaults to the project root.
+    require_api_key:
+        When ``True`` a missing ``LLM_API_KEY`` results in :class:`RuntimeError`.
+    """
+
+    env_path = env_file if env_file is not None else DEFAULT_ENV_FILE
+    _load_dotenv(env_path)
+
+    provider = os.getenv("LLM_PROVIDER", "openrouter")
+    api_key = os.getenv("LLM_API_KEY") or os.getenv("OPENAI_API_KEY")
+    base_url = os.getenv("LLM_BASE_URL")
+    model = os.getenv("LLM_MODEL", "gpt-4.1-mini")
+
+    temperature_str = os.getenv("LLM_TEMPERATURE", "0.2")
+    max_tokens_str = os.getenv("LLM_MAX_TOKENS", "1024")
+
+    try:
+        temperature = float(temperature_str)
+    except ValueError as exc:  # pragma: no cover - guard rails
+        raise RuntimeError("LLM_TEMPERATURE must be a float") from exc
+
+    try:
+        max_tokens = int(max_tokens_str)
+    except ValueError as exc:  # pragma: no cover - guard rails
+        raise RuntimeError("LLM_MAX_TOKENS must be an integer") from exc
+
+    if require_api_key and not api_key:
+        raise RuntimeError(
+            "Missing LLM_API_KEY environment variable. Set it in the .env file before "
+            "attempting to use LLM-powered agents."
+        )
+
+    return LLMConfig(
+        provider=provider,
+        api_key=api_key,
+        base_url=base_url,
+        model=model,
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
+
+
+__all__ = ["LLMConfig", "load_llm_config"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 pandas
 yfinance
+python-dotenv


### PR DESCRIPTION
## Summary
- add a committed `.env` template with placeholder LLM provider settings and document the variables in the README
- introduce `investment_company.config` to centralize loading of LLM environment settings and expose helper methods
- export the configuration helpers via the package init and record the optional python-dotenv dependency

## Testing
- python -m compileall investment_company main.py

------
https://chatgpt.com/codex/tasks/task_e_68d15c705f808332b3efd8958c280c92